### PR TITLE
Adds plugin.source to GCP Dataflow template

### DIFF
--- a/src/main/java/com/google/cloud/teleport/newrelic/utils/HttpClient.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/utils/HttpClient.java
@@ -14,6 +14,7 @@ import com.google.api.client.util.StringUtils;
 import com.google.cloud.teleport.newrelic.dtos.NewRelicLogRecord;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -175,12 +176,18 @@ public class HttpClient {
      * Utility method to transform a list of {@link NewRelicLogRecord}s into the body of the HTTP call to New Relic
      */
     private String buildBody(List<NewRelicLogRecord> logRecords) {
-        final JsonObject commonAttributes = new JsonObject();
-        commonAttributes.addProperty(PLUGIN_SOURCE_ATTR, PLUGIN_SOURCE_VALUE);
-        final JsonObject payload = new JsonObject();
-        payload.add("common", commonAttributes);
-        payload.add("logs", GSON.toJsonTree(logRecords, new TypeToken<List<NewRelicLogRecord>>() {
-        }.getType()));
+        final JsonObject common = new JsonObject();
+        final JsonObject attributes = new JsonObject();
+        attributes.addProperty(PLUGIN_SOURCE_ATTR, PLUGIN_SOURCE_VALUE);
+        common.add("attributes", attributes);
+
+        final JsonObject logsBlock = new JsonObject();
+        logsBlock.add("common", common);
+        logsBlock.add("logs", GSON.toJsonTree(logRecords, new TypeToken<List<NewRelicLogRecord>>() {}.getType()));
+
+        final JsonArray payload = new JsonArray();
+        payload.add(logsBlock);
+
         return payload.toString();
     }
 

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
@@ -75,6 +75,8 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
  */
 public class PubsubToNewRelic {
 
+    public static final String PLUGIN_VERSION = "1.0.0";
+
     /**
      * String/String Coder for FailsafeElement.
      */

--- a/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
+++ b/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
@@ -288,15 +288,23 @@ public class NewRelicPipelineTest {
     }
 
     private String jsonArrayOf(final JsonObject... jsonObjects) {
-        JsonObject payload = new JsonObject();
-        JsonObject commonPayload = new JsonObject();
-        commonPayload.addProperty("plugin.source", "gcp-dataflow-" + PLUGIN_VERSION);
-        payload.add("common", commonPayload);
-        JsonArray logs = new JsonArray();
+        final JsonObject attributes = new JsonObject();
+        attributes.addProperty("plugin.source", "gcp-dataflow-" + PLUGIN_VERSION);
+        final JsonObject common = new JsonObject();
+        common.add("attributes", attributes);
+
+        final JsonArray logs = new JsonArray();
         for (JsonObject obj : jsonObjects) {
             logs.add(obj);
         }
-        payload.add("logs", logs);
+
+        final JsonObject logsBlock = new JsonObject();
+        logsBlock.add("common", common);
+        logsBlock.add("logs", logs);
+
+        final JsonArray payload = new JsonArray();
+        payload.add(logsBlock);
+
         return payload.toString();
     }
 }

--- a/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
+++ b/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
@@ -29,6 +29,7 @@ import java.time.ZoneOffset;
 
 import static com.google.cloud.teleport.newrelic.utils.HttpClient.APPLICATION_GZIP;
 import static com.google.cloud.teleport.newrelic.utils.HttpClient.APPLICATION_JSON;
+import static com.google.cloud.teleport.templates.PubsubToNewRelic.PLUGIN_VERSION;
 import static org.junit.Assume.assumeNoException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -287,10 +288,15 @@ public class NewRelicPipelineTest {
     }
 
     private String jsonArrayOf(final JsonObject... jsonObjects) {
-        JsonArray arr = new JsonArray();
+        JsonObject payload = new JsonObject();
+        JsonObject commonPayload = new JsonObject();
+        commonPayload.addProperty("plugin.source", "gcp-dataflow-" + PLUGIN_VERSION);
+        payload.add("common", commonPayload);
+        JsonArray logs = new JsonArray();
         for (JsonObject obj : jsonObjects) {
-            arr.add(obj);
+            logs.add(obj);
         }
-        return arr.toString();
+        payload.add("logs", logs);
+        return payload.toString();
     }
 }


### PR DESCRIPTION
### Background
The GCP Dataflow template to send logs to New Relic didn't include any information to detect how the data was packaged when it reaches New Relic. This PR includes the `plugin.source` field, with the format `gcp-dataflow-{VERSION}`.

### Changes included in this PR
Modifies how the HTTP body is built. Before, it was just forwarding a JSON array. Now, it follows the MELT format (`detailed JSON body message` described [here](https://docs.newrelic.com/docs/logs/log-management/log-api/introduction-log-api/#json-content)) and includes the `plugin.source` as a common attribute.

### Tests
Integration tests have been adapted to expect the new payload. Manual tests performed manually by me by deploying the template to GCP.