### PR TITLE
Add processing-time-based window triggering

### DIFF
--- a/src/main/java/com/google/cloud/teleport/newrelic/dofns/NewRelicLogRecordWriterFn.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/dofns/NewRelicLogRecordWriterFn.java
@@ -79,7 +79,7 @@ public class NewRelicLogRecordWriterFn
   private final StateSpec<ValueState<Long>> count = StateSpecs.value();
 
   @TimerId(TIME_ID_NAME)
-  private final TimerSpec expirySpec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+  private final TimerSpec expirySpec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
 
   // Non-serialized fields: these are set up once the DoFn has potentially been deserialized, in the
   // @Setup method.

--- a/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
+++ b/src/test/java/com/google/cloud/teleport/newrelic/NewRelicPipelineTest.java
@@ -128,16 +128,22 @@ public class NewRelicPipelineTest {
   @Test
   public void testMessagesAreBatchedCorrectly() {
     // Given
+    final int flushDelay = 2;
+    final TestStream<String> logRecordLines =
+      TestStream.create(StringUtf8Coder.of())
+        .addElements(PLAINTEXT_MESSAGE,
+          PLAINTEXT_MESSAGE,
+          PLAINTEXT_MESSAGE,
+          PLAINTEXT_MESSAGE,
+          PLAINTEXT_MESSAGE)
+        .advanceProcessingTime(Duration.standardSeconds(2 * flushDelay))
+        .advanceWatermarkToInfinity();
+
     NewRelicPipeline pipeline =
       new NewRelicPipeline(
         testPipeline,
-        Create.of(
-          PLAINTEXT_MESSAGE,
-          PLAINTEXT_MESSAGE,
-          PLAINTEXT_MESSAGE,
-          PLAINTEXT_MESSAGE,
-          PLAINTEXT_MESSAGE),
-        new NewRelicIO(getPipelineOptions(url, 2, 2, 1, false)));
+        logRecordLines,
+        new NewRelicIO(getPipelineOptions(url, 2, flushDelay, 1, false)));
 
     // When
     pipeline.run().waitUntilFinish(Duration.millis(100));
@@ -163,10 +169,10 @@ public class NewRelicPipelineTest {
     final int flushDelay = 2;
     final TestStream<String> logRecordLines =
       TestStream.create(StringUtf8Coder.of())
-        .advanceWatermarkTo(new Instant(0))
         .addElements(PLAINTEXT_MESSAGE)
-        .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(flushDelay - 1)))
+        .advanceProcessingTime(Duration.standardSeconds(flushDelay - 1))
         .addElements(JSON_MESSAGE)
+        .advanceProcessingTime(Duration.standardSeconds(2*flushDelay))
         .advanceWatermarkToInfinity();
 
     NewRelicPipeline pipeline =
@@ -195,10 +201,10 @@ public class NewRelicPipelineTest {
     final int flushDelay = 2;
     final TestStream<String> logRecordLines =
       TestStream.create(StringUtf8Coder.of())
-        .advanceWatermarkTo(new Instant(0))
         .addElements(PLAINTEXT_MESSAGE)
-        .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(flushDelay + 1)))
+        .advanceProcessingTime(Duration.standardSeconds(flushDelay + 1))
         .addElements(JSON_MESSAGE)
+        .advanceProcessingTime(Duration.standardSeconds(2 * flushDelay))
         .advanceWatermarkToInfinity();
 
     NewRelicPipeline pipeline =


### PR DESCRIPTION
Leaving this here in case we end up going for this alternative triggering implementation in our pipeline. These code changes perform the window triggering each second, based on the processing time instead of the event time (watermark-triggered).