### PR TITLE
NR-560783: Add JP region support documentation to New Relic Dataflow templates

### DIFF
--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
@@ -26,13 +26,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * send the processed logs to New Relic.
  */
 public class NewRelicConfig {
-  // Region-specific New Relic Logs API endpoints
-  protected static final String LOGS_API_URL_US = "https://log-api.newrelic.com/log/v1";
-  protected static final String LOGS_API_URL_EU = "https://log-api.eu.newrelic.com/log/v1";
-  protected static final String LOGS_API_URL_JP = "https://log-api.jp.newrelic.com/log/v1";
-
-  // Default to US region for backward compatibility
-  protected static final String DEFAULT_LOGS_API_URL = LOGS_API_URL_US;
+  protected static final String DEFAULT_LOGS_API_URL = "https://log-api.newrelic.com/log/v1";
   protected static final int DEFAULT_BATCH_COUNT = 100;
   protected static final boolean DEFAULT_DISABLE_CERTIFICATE_VALIDATION = false;
   protected static final boolean DEFAULT_USE_COMPRESSION = true;

--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
@@ -26,7 +26,13 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * send the processed logs to New Relic.
  */
 public class NewRelicConfig {
-  protected static final String DEFAULT_LOGS_API_URL = "https://log-api.newrelic.com/log/v1";
+  // Region-specific New Relic Logs API endpoints
+  protected static final String LOGS_API_URL_US = "https://log-api.newrelic.com/log/v1";
+  protected static final String LOGS_API_URL_EU = "https://log-api.eu.newrelic.com/log/v1";
+  protected static final String LOGS_API_URL_JP = "https://log-api.jp.newrelic.com/log/v1";
+
+  // Default to US region for backward compatibility
+  protected static final String DEFAULT_LOGS_API_URL = LOGS_API_URL_US;
   protected static final int DEFAULT_BATCH_COUNT = 100;
   protected static final boolean DEFAULT_DISABLE_CERTIFICATE_VALIDATION = false;
   protected static final boolean DEFAULT_USE_COMPRESSION = true;

--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
@@ -32,7 +32,10 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
   void setLicenseKey(ValueProvider<String> licenseKey);
 
   @Description(
-      "New Relic Logs API url. This should be routable from the VPC in which the Dataflow pipeline runs.")
+      "New Relic Logs API url. This should be routable from the VPC in which the Dataflow pipeline runs. "
+          + "Supported regions: US (https://log-api.newrelic.com/log/v1), "
+          + "EU (https://log-api.eu.newrelic.com/log/v1), "
+          + "JP (https://log-api.jp.newrelic.com/log/v1)")
   ValueProvider<String> getLogsApiUrl();
 
   void setLogsApiUrl(ValueProvider<String> logsApiUrl);

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
@@ -64,7 +64,6 @@ import org.slf4j.LoggerFactory;
  * <p># US Region: NR_LOG_ENDPOINT=https://log-api.newrelic.com/log/v1
  * <p># EU Region: NR_LOG_ENDPOINT=https://log-api.eu.newrelic.com/log/v1
  * <p># JP Region: NR_LOG_ENDPOINT=https://log-api.jp.newrelic.com/log/v1
- * <p>NR_LOG_ENDPOINT=https://log-api.newrelic.com/log/v1
  *
  * <p>NR_LICENSE_KEY=YOUR NEW RELIC LICENSE KEY
  *

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
@@ -60,6 +60,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>INPUT_SUB_NAME=SUB NAME WHERE LOGS ARE
  *
+ * <p># New Relic Logs API endpoint (choose based on your region):
+ * <p># US Region: NR_LOG_ENDPOINT=https://log-api.newrelic.com/log/v1
+ * <p># EU Region: NR_LOG_ENDPOINT=https://log-api.eu.newrelic.com/log/v1
+ * <p># JP Region: NR_LOG_ENDPOINT=https://log-api.jp.newrelic.com/log/v1
  * <p>NR_LOG_ENDPOINT=https://log-api.newrelic.com/log/v1
  *
  * <p>NR_LICENSE_KEY=YOUR NEW RELIC LICENSE KEY


### PR DESCRIPTION
## Summary
Documentation-only changes to add JP region support to the New Relic Logs API integration. The system is already region-agnostic and accepts any endpoint URL via the `logsApiUrl` parameter - these changes document the JP endpoint for users.

## Changes Made

**Files Modified:**
1. **PubsubToNewRelic.java** (Lines 63-67)
   - Added documentation showing all three regional endpoints (US, EU, JP) in usage examples
   
2. **NewRelicPipelineOptions.java** (Lines 34-38)
   - Enhanced `@Description` for `logsApiUrl` parameter to list all supported regions with their endpoints

**No functional code changes** - the pipeline already supports any endpoint URL via runtime parameters.

## Regional Endpoints Documented

- **US**: `https://log-api.newrelic.com/log/v1` (default)
- **EU**: `https://log-api.eu.newrelic.com/log/v1`
- **JP**: `https://log-api.jp.newrelic.com/log/v1` *(pre-launch - endpoint not yet live)*

Relates to [NR-560783](https://new-relic.atlassian.net/browse/NR-560783)