### PR TITLE
Update JP endpoint from jp.newrelic.com to jp.nr-data.net

### DIFF
--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
@@ -35,7 +35,7 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
       "New Relic Logs API url. This should be routable from the VPC in which the Dataflow pipeline runs. "
           + "Supported regions: US (https://log-api.newrelic.com/log/v1), "
           + "EU (https://log-api.eu.newrelic.com/log/v1), "
-          + "JP (https://log-api.jp.newrelic.com/log/v1)")
+          + "JP (https://log-api.jp.nr-data.net/log/v1)")
   ValueProvider<String> getLogsApiUrl();
 
   void setLogsApiUrl(ValueProvider<String> logsApiUrl);

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToNewRelic.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * <p># New Relic Logs API endpoint (choose based on your region):
  * <p># US Region: NR_LOG_ENDPOINT=https://log-api.newrelic.com/log/v1
  * <p># EU Region: NR_LOG_ENDPOINT=https://log-api.eu.newrelic.com/log/v1
- * <p># JP Region: NR_LOG_ENDPOINT=https://log-api.jp.newrelic.com/log/v1
+ * <p># JP Region: NR_LOG_ENDPOINT=https://log-api.jp.nr-data.net/log/v1
  *
  * <p>NR_LICENSE_KEY=YOUR NEW RELIC LICENSE KEY
  *


### PR DESCRIPTION
Updated JP region endpoint to use the new domain jp.nr-data.net instead of jp.newrelic.com in documentation and configuration.