### PR TITLE
fix: logsApiUrl runtime parameter not being applied

### DIFF
--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
@@ -26,13 +26,6 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * send the processed logs to New Relic.
  */
 public class NewRelicConfig {
-  protected static final String DEFAULT_LOGS_API_URL = "https://log-api.newrelic.com/log/v1";
-  protected static final int DEFAULT_BATCH_COUNT = 100;
-  protected static final boolean DEFAULT_DISABLE_CERTIFICATE_VALIDATION = false;
-  protected static final boolean DEFAULT_USE_COMPRESSION = true;
-  protected static final int DEFAULT_FLUSH_DELAY = 2;
-  protected static final Integer DEFAULT_PARALLELISM = 1;
-
   private final ValueProvider<String> logsApiUrl;
   private final ValueProvider<String> licenseKey;
   private final ValueProvider<Integer> batchCount;
@@ -60,28 +53,24 @@ public class NewRelicConfig {
 
   /**
    * Factory method to build a {@link NewRelicConfig} out of the supplied {@link
-   * NewRelicPipelineOptions} supplied by the user. The method takes care of configuring the default
-   * values if the user provided a null value for any of them.
+   * NewRelicPipelineOptions} supplied by the user. Default values are configured via @Default
+   * annotations in {@link NewRelicPipelineOptions}.
    *
    * @param newRelicOptions The supplied options when executing the pipeline
    * @return The options to be used to execute the pipeline.
    */
   public static NewRelicConfig fromPipelineOptions(final NewRelicPipelineOptions newRelicOptions) {
     return new NewRelicConfig(
-        newRelicOptions.getLogsApiUrl() != null
-            ? newRelicOptions.getLogsApiUrl()
-            : ValueProvider.StaticValueProvider.of(DEFAULT_LOGS_API_URL),
+        newRelicOptions.getLogsApiUrl(),
         newRelicOptions.getTokenKMSEncryptionKey().isAccessible()
             ? maybeDecrypt(
                 newRelicOptions.getLicenseKey(), newRelicOptions.getTokenKMSEncryptionKey())
             : newRelicOptions.getLicenseKey(),
-        valueOrDefault(newRelicOptions.getBatchCount(), DEFAULT_BATCH_COUNT),
-        valueOrDefault(newRelicOptions.getFlushDelay(), DEFAULT_FLUSH_DELAY),
-        valueOrDefault(newRelicOptions.getParallelism(), DEFAULT_PARALLELISM),
-        valueOrDefault(
-            newRelicOptions.getDisableCertificateValidation(),
-            DEFAULT_DISABLE_CERTIFICATE_VALIDATION),
-        valueOrDefault(newRelicOptions.getUseCompression(), DEFAULT_USE_COMPRESSION));
+        newRelicOptions.getBatchCount(),
+        newRelicOptions.getFlushDelay(),
+        newRelicOptions.getParallelism(),
+        newRelicOptions.getDisableCertificateValidation(),
+        newRelicOptions.getUseCompression());
   }
 
   /**
@@ -138,20 +127,4 @@ public class NewRelicConfig {
         .toString();
   }
 
-  /**
-   * Returns the value included in the provided ValueProvider, if it's available and non-null. In
-   * any other case, it returns the default value provided in the second argument.
-   *
-   * @param value The value to use, if it's non-null.
-   * @param defaultValue Fallback value to use if the provided ValueProvider is null or holds a null
-   *     value.
-   * @param <T> The type of the value being read
-   * @return The value included in the provided ValueProvider, if it's available and non-null,
-   *     otherwise the default value.
-   */
-  private static <T> ValueProvider<T> valueOrDefault(ValueProvider<T> value, T defaultValue) {
-    return (value != null && value.isAccessible()) && value.get() != null
-        ? ValueProvider.StaticValueProvider.of(value.get())
-        : ValueProvider.StaticValueProvider.of(defaultValue);
-  }
 }

--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicConfig.java
@@ -68,7 +68,9 @@ public class NewRelicConfig {
    */
   public static NewRelicConfig fromPipelineOptions(final NewRelicPipelineOptions newRelicOptions) {
     return new NewRelicConfig(
-        valueOrDefault(newRelicOptions.getLogsApiUrl(), DEFAULT_LOGS_API_URL),
+        newRelicOptions.getLogsApiUrl() != null
+            ? newRelicOptions.getLogsApiUrl()
+            : ValueProvider.StaticValueProvider.of(DEFAULT_LOGS_API_URL),
         newRelicOptions.getTokenKMSEncryptionKey().isAccessible()
             ? maybeDecrypt(
                 newRelicOptions.getLicenseKey(), newRelicOptions.getTokenKMSEncryptionKey())

--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
@@ -27,6 +27,14 @@ import org.apache.beam.sdk.options.ValueProvider;
  * {@link NewRelicLogRecordWriterFn}.
  */
 public interface NewRelicPipelineOptions extends PipelineOptions {
+  // Default values for pipeline options
+  String DEFAULT_LOGS_API_URL = "https://log-api.newrelic.com/log/v1";
+  int DEFAULT_BATCH_COUNT = 100;
+  int DEFAULT_FLUSH_DELAY = 2;
+  int DEFAULT_PARALLELISM = 1;
+  boolean DEFAULT_DISABLE_CERTIFICATE_VALIDATION = false;
+  boolean DEFAULT_USE_COMPRESSION = true;
+
   @Description("New Relic license key.")
   ValueProvider<String> getLicenseKey();
 
@@ -37,14 +45,14 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
           + "Supported regions: US (https://log-api.newrelic.com/log/v1), "
           + "EU (https://log-api.eu.newrelic.com/log/v1), "
           + "JP (https://log-api.jp.nr-data.net/log/v1)")
-  @Default.String("https://log-api.newrelic.com/log/v1")
+  @Default.String(DEFAULT_LOGS_API_URL)
   ValueProvider<String> getLogsApiUrl();
 
   void setLogsApiUrl(ValueProvider<String> logsApiUrl);
 
   @Description(
       "Maximum number of log records to aggregate into a batch before sending them to NewRelic in a single HTTP POST request.")
-  @Default.Integer(100)
+  @Default.Integer(DEFAULT_BATCH_COUNT)
   ValueProvider<Integer> getBatchCount();
 
   void setBatchCount(ValueProvider<Integer> batchCount);
@@ -53,17 +61,17 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
 
   @Description(
       "Number of seconds to wait for additional logs (up to batchCount) since the reception of the last log record in non-full batch, before flushing them to New Relic Logs.")
-  @Default.Integer(2)
+  @Default.Integer(DEFAULT_FLUSH_DELAY)
   ValueProvider<Integer> getFlushDelay();
 
   @Description("Disable SSL certificate validation.")
-  @Default.Boolean(false)
+  @Default.Boolean(DEFAULT_DISABLE_CERTIFICATE_VALIDATION)
   ValueProvider<Boolean> getDisableCertificateValidation();
 
   void setDisableCertificateValidation(ValueProvider<Boolean> disableCertificateValidation);
 
   @Description("Maximum number of parallel requests.")
-  @Default.Integer(1)
+  @Default.Integer(DEFAULT_PARALLELISM)
   ValueProvider<Integer> getParallelism();
 
   void setParallelism(ValueProvider<Integer> parallelism);
@@ -76,7 +84,7 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
   void setTokenKMSEncryptionKey(ValueProvider<String> keyName);
 
   @Description("True to compress (in GZIP) the payloads sent to the New Relic Logs API.")
-  @Default.Boolean(true)
+  @Default.Boolean(DEFAULT_USE_COMPRESSION)
   ValueProvider<Boolean> getUseCompression();
 
   void setUseCompression(ValueProvider<Boolean> useCompression);

--- a/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
+++ b/src/main/java/com/google/cloud/teleport/newrelic/config/NewRelicPipelineOptions.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.newrelic.config;
 
 import com.google.cloud.teleport.newrelic.dofns.NewRelicLogRecordWriterFn;
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -36,12 +37,14 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
           + "Supported regions: US (https://log-api.newrelic.com/log/v1), "
           + "EU (https://log-api.eu.newrelic.com/log/v1), "
           + "JP (https://log-api.jp.nr-data.net/log/v1)")
+  @Default.String("https://log-api.newrelic.com/log/v1")
   ValueProvider<String> getLogsApiUrl();
 
   void setLogsApiUrl(ValueProvider<String> logsApiUrl);
 
   @Description(
       "Maximum number of log records to aggregate into a batch before sending them to NewRelic in a single HTTP POST request.")
+  @Default.Integer(100)
   ValueProvider<Integer> getBatchCount();
 
   void setBatchCount(ValueProvider<Integer> batchCount);
@@ -50,14 +53,17 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
 
   @Description(
       "Number of seconds to wait for additional logs (up to batchCount) since the reception of the last log record in non-full batch, before flushing them to New Relic Logs.")
+  @Default.Integer(2)
   ValueProvider<Integer> getFlushDelay();
 
   @Description("Disable SSL certificate validation.")
+  @Default.Boolean(false)
   ValueProvider<Boolean> getDisableCertificateValidation();
 
   void setDisableCertificateValidation(ValueProvider<Boolean> disableCertificateValidation);
 
   @Description("Maximum number of parallel requests.")
+  @Default.Integer(1)
   ValueProvider<Integer> getParallelism();
 
   void setParallelism(ValueProvider<Integer> parallelism);
@@ -70,6 +76,7 @@ public interface NewRelicPipelineOptions extends PipelineOptions {
   void setTokenKMSEncryptionKey(ValueProvider<String> keyName);
 
   @Description("True to compress (in GZIP) the payloads sent to the New Relic Logs API.")
+  @Default.Boolean(true)
   ValueProvider<Boolean> getUseCompression();
 
   void setUseCompression(ValueProvider<Boolean> useCompression);

--- a/src/test/java/com/google/cloud/teleport/newrelic/config/NewRelicConfigTest.java
+++ b/src/test/java/com/google/cloud/teleport/newrelic/config/NewRelicConfigTest.java
@@ -15,12 +15,12 @@
  */
 package com.google.cloud.teleport.newrelic.config;
 
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_BATCH_COUNT;
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_DISABLE_CERTIFICATE_VALIDATION;
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_FLUSH_DELAY;
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_LOGS_API_URL;
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_PARALLELISM;
-import static com.google.cloud.teleport.newrelic.config.NewRelicConfig.DEFAULT_USE_COMPRESSION;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_BATCH_COUNT;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_DISABLE_CERTIFICATE_VALIDATION;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_FLUSH_DELAY;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_LOGS_API_URL;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_PARALLELISM;
+import static com.google.cloud.teleport.newrelic.config.NewRelicPipelineOptions.DEFAULT_USE_COMPRESSION;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## Problem

The `logsApiUrl` parameter (and other runtime parameters) were not working for EU and JP customers. When users specified:
```bash
--parameters="logsApiUrl=https://log-api.eu.newrelic.com/log/v1"
```

The job would still send logs to the US endpoint (`https://log-api.newrelic.com/log/v1`), causing 403 authentication errors.

## Root Cause

The `valueOrDefault()` method checked `isAccessible()` at template build time, when runtime parameters are not yet available. This caused default values to be baked into the template as `StaticValueProvider`, preventing runtime overrides.

## Solution

Following Apache Beam best practices (as suggested by @maya-jha), this PR uses `@Default` annotations to handle default values properly:

**Changes:**
1. Added `@Default` annotations to all parameters in `NewRelicPipelineOptions.java`
2. Simplified `NewRelicConfig.fromPipelineOptions()` to directly pass through options
3. Removed `valueOrDefault()` method and all `DEFAULT_*` constants
4. Beam framework now handles defaults at runtime (not build time)

**Benefits:**
- ✅ Follows Apache Beam best practices
- ✅ Fixes runtime parameter override for **all** configurable parameters
- ✅ Cleaner, more maintainable code
- ✅ Enables EU and JP region support

## Testing

After this fix, customers can successfully override parameters at runtime:
- `logsApiUrl`: EU (`https://log-api.eu.newrelic.com/log/v1`) or JP (`https://log-api.jp.nr-data.net/log/v1`)
- `batchCount`, `flushDelay`, `parallelism`, etc.

## Impact

This fixes a critical bug that has prevented EU customers from using the template, and enables JP region support.