### PR TITLE
fix: remediate straightforward Dependabot vulnerabilities via version bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <extra.enforcer.rules.version>1.3</extra.enforcer.rules.version>
     <hamcrest.version>2.1</hamcrest.version>
     <java.version>1.8</java.version>
-    <junit.version>4.13</junit.version>
+    <junit.version>4.13.1</junit.version>
     <surefire.version>2.21.0</surefire.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
@@ -60,28 +60,29 @@
     <bigtable.version>1.15.0</bigtable.version>
     <bigtable-beam-import.version>1.15.0</bigtable-beam-import.version>
     <protobuf.version>3.11.1</protobuf.version>
-    <json.version>20200518</json.version>
+    <json.version>20231013</json.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>
     <re2j.version>1.4</re2j.version>
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
     <commons-csv.version>1.8</commons-csv.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
     <google-cloud-bigquery.version>1.108.0</google-cloud-bigquery.version>
     <grpc.version>1.13.1</grpc.version>
     <mvn-target-dir>${basedir}/target</mvn-target-dir>
     <derby.version>10.14.2.0</derby.version>
     <commons-codec.version>1.14</commons-codec.version>
-    <commons-io.version>2.4</commons-io.version>
-    <kafka.clients.version>1.0.0</kafka.clients.version>
+    <commons-io.version>2.14.0</commons-io.version>
+    <kafka.clients.version>3.9.2</kafka.clients.version>
     <threetenbp.version>1.4.4</threetenbp.version>
-    <spring.version>5.2.8.RELEASE</spring.version>
+    <spring.version>5.3.39</spring.version>
     <autovalue.annotations.version>1.7.4</autovalue.annotations.version>
     <autovalue.version>1.7.4</autovalue.version>
     <excluded.spanner.tests>com.google.cloud.teleport.spanner.IntegrationTest</excluded.spanner.tests>
     <tensorflow.version>1.15.0</tensorflow.version>
     <truth.version>1.0.1</truth.version>
     <dlp.version>2.1.0</dlp.version>
-    <hadoop.version>2.8.5</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hbase.version>1.4.5</hbase.version>
     <scassandra.version>1.1.2</scassandra.version>
     <cassandra.driver.version>3.6.0</cassandra.driver.version>
@@ -98,6 +99,11 @@
           <version>${beam.version}</version>
           <type>pom</type>
           <scope>import</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>${commons-lang3.version}</version>
         </dependency>
       </dependencies>
     </dependencyManagement>

--- a/v2/cdc-parent/cdc-embedded-connector/pom.xml
+++ b/v2/cdc-parent/cdc-embedded-connector/pom.xml
@@ -141,13 +141,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.5</version>
+      <version>2.15.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.3</version>
+      <version>1.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/v2/cdc-parent/pom.xml
+++ b/v2/cdc-parent/pom.xml
@@ -32,8 +32,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <debezium.version>0.9.5.Final</debezium.version>
-    <grpc.version>1.35.0</grpc.version>
-    <guava.version>25.1-jre</guava.version>
+    <grpc.version>1.75.0</grpc.version>
+    <guava.version>32.0.0-android</guava.version>
     <gcp.version>1.82.0</gcp.version>
     <data-catalog.version>0.35.0</data-catalog.version>
   </properties>

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -30,7 +30,7 @@
         <avro.version>1.8.2</avro.version>
         <bigquery.version>1.128.0</bigquery.version>
         <commons.version>1.8</commons.version>
-        <commons-text.version>1.9</commons-text.version>
+        <commons-text.version>1.10.0</commons-text.version>
         <protoc.version>3.15.8</protoc.version>
         <truth.version>1.0.1</truth.version>
         <truth-proto-extension.version>1.0.1</truth-proto-extension.version>

--- a/v2/datastream-to-postgres/pom.xml
+++ b/v2/datastream-to-postgres/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.2</version>
+            <version>42.7.11</version>
         </dependency>
     </dependencies>
 

--- a/v2/datastream-to-spanner/pom.xml
+++ b/v2/datastream-to-spanner/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20160810</version>
+            <version>20231013</version>
         </dependency>
     </dependencies>
 

--- a/v2/datastream-to-sql/pom.xml
+++ b/v2/datastream-to-sql/pom.xml
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.2</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.13</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
         </dependency>
     </dependencies>
 

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -35,7 +35,7 @@
     <mockito.version>1.10.19</mockito.version>
     <mockito-core.version>3.0.0</mockito-core.version>
     <derby.version>10.14.2.0</derby.version>
-    <hadoop.version>2.8.5</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
   </properties>
 
   <build>

--- a/v2/hive-to-bigquery/pom.xml
+++ b/v2/hive-to-bigquery/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.3</version>
+            <version>0.23.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/v2/kafka-common/pom.xml
+++ b/v2/kafka-common/pom.xml
@@ -25,7 +25,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <kafka-clients.version>2.3.0</kafka-clients.version>
+    <kafka-clients.version>3.9.2</kafka-clients.version>
   </properties>
 
   <dependencies>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -32,11 +32,11 @@
         <beam.version>2.32.0</beam.version>
         <beam-vendor-guava.version>0.1</beam-vendor-guava.version>
         <hamcrest.version>2.1</hamcrest.version>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
         <guava.version>30.1-jre</guava.version>
         <java.version>1.8</java.version>
         <jib.maven.version>2.6.0</jib.maven.version>
-        <junit.version>4.13</junit.version>
+        <junit.version>4.13.1</junit.version>
         <junit-dep.version>4.10</junit-dep.version>
         <opensensus.version>0.24.0</opensensus.version>
         <surefire.version>2.21.0</surefire.version>
@@ -52,7 +52,7 @@
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <slf4j.version>1.7.25</slf4j.version>
         <mvn-target-dir>${basedir}/target</mvn-target-dir>
-        <json.version>20200518</json.version>
+        <json.version>20231013</json.version>
         <excluded.spanner.tests>com.google.cloud.teleport.v2.spanner.IntegrationTest</excluded.spanner.tests>
         <spotless-maven-plugin.version>2.12.1</spotless-maven-plugin.version>
     </properties>

--- a/v2/streaming-data-generator/pom.xml
+++ b/v2/streaming-data-generator/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <json-data-generator.version>1.10</json-data-generator.version>
-    <snakeyaml.version>1.23</snakeyaml.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
    </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

Fixes **71 of 91** open Dependabot alerts on `master` by bumping vulnerable dependency versions. **Version bumps only — no source code changes.** Every target version was verified to (a) actually exist on Maven Central, (b) resolve without conflicts, and (c) compile and pass the existing test suite before being included.

Also verified end-to-end on GCP: rebuilt and staged the `PubsubToNewRelic` Dataflow template from this branch and ran it against a live Pub/Sub topic — logs were confirmed delivered to New Relic with all patched dependencies in place.

## Fixed (16 packages, 71 alerts)

| Package | From → To | Alerts fixed |
|---|---|---|
| `org.springframework:spring-expression` | 5.2.8.RELEASE → 5.3.39 | 4 |
| `org.apache.hadoop:hadoop-common` | 2.8.5/2.10.1 → 2.10.2 | 8 |
| `org.postgresql:postgresql` | 42.2.2 → 42.7.11 | 16 |
| `org.apache.kafka:kafka-clients` | 1.0.0/2.3.0 → 3.9.2 | 4 |
| `mysql:mysql-connector-java` → `com.mysql:mysql-connector-j` | 8.0.13 → 8.4.0 | 4 |
| `commons-io:commons-io` | 2.4 → 2.14.0 | 2 |
| `org.json:json` | 20160810/20200518 → 20231013 | 6 |
| `org.apache.commons:commons-text` | 1.9 → 1.10.0 | 2 |
| `junit:junit` | 4.13 → 4.13.1 (test-scope) | 2 |
| `io.grpc:grpc-netty-shaded` | 1.35.0 → 1.75.0 | 1 |
| `com.google.guava:guava` | 25.1-jre → 32.0.0-android | 2 |
| `org.apache.commons:commons-configuration2` | 2.5 → 2.15.0 | 5 |
| `commons-beanutils:commons-beanutils` | 1.9.3 → 1.11.0 | 3 |
| `org.apache.thrift:libthrift` | 0.9.3 → 0.23.0 | 4 |
| `org.yaml:snakeyaml` | 1.23 → 2.0 | 8 |
| `org.apache.commons:commons-lang3` (new pin) | unpinned → 3.12.0 | — (see below) |

The `commons-lang3` pin isn't itself a CVE fix — it was needed *because* of the `hadoop.version` bump: Hadoop's own direct `commons-lang3:3.4` dependency started winning Maven's "nearest wins" mediation over `commons-text`'s transitive `commons-lang3:3.11/3.12`, silently downgrading the effective classpath version and breaking MockServer-based tests (`NewRelicPipelineTest`) at runtime. Pinning it in `dependencyManagement` restores the correct version with no code changes.

## Explicitly NOT fixed (20 alerts) — verified unsafe/impossible as version-only changes

- **`org.apache.derby:derby`** (2 alerts, CVE-2022-46337): the advisory's patched version `10.14.2.1` for the Java-8-compatible 10.14 line was **never published to Maven Central** — upstream's own mitigation note says to "build your own Derby distribution from source." No valid artifact exists to bump to.
- **`org.apache.avro:avro`** (6 alerts, CVE-2024-47561/CVE-2023-39410): any version past `1.8.2` changes `DateConversion.fromInt()`'s return type (`org.joda.time.LocalDate` → `java.time.LocalDate`) and makes `GenericRecord.get()` throw `AvroRuntimeException` instead of returning `null` for schema fields absent from a given record variant. Both are real behavioral breaks requiring source changes — out of scope for a version-only fix.
- **`org.codehaus.jackson:jackson-mapper-asl`** (2 alerts): dead project, no patched version exists under this coordinate at all. Removing it requires migrating `ConsumerSpEL.java` off Spring's SpEL entirely — a source change.
- **`spring-expression`'s newest CVEs** (4 alerts, CVE-2026-41849/50/51/52): only fixed in Spring Framework 6.2.19+, which requires Java 17+ and breaking API changes (this project targets Java 8). Out of scope.
- **`com.puppycrawl.tools:checkstyle`** (4 alerts): bumping past `8.7` requires `maven-checkstyle-plugin >= 3.1` (confirmed — 3.0.0 throws `NoSuchMethodError` against newer Checkstyle) **and** the newer Checkstyle ruleset flags 7 real style violations in existing source that would need fixing. A version bump alone doesn't clear the build.

## Verification

- Full reactor `compile` + `test` run, both root project and `v2/`, on Java 8 (this project's target)
- Diffed every remaining test failure against an unmodified `master` baseline to confirm each is pre-existing and unrelated to these changes: `JavascriptTextTransformerTest`, `PubsubToBigQueryTest`, `NewRelicConfigTest`, `HttpEventPublisherTest`, `CustomX509TrustManagerTest`, `KafkaToBigQueryTest`, `CsvConvertersTest` — same failure counts before and after
- Live GCP smoke test: staged the `PubsubToNewRelic` template from this branch to GCS, launched a Dataflow job against a real Pub/Sub subscription, and confirmed the log record reached New Relic

## Test plan

- [x] `mvn compile` succeeds (root + `v2/`)
- [x] `mvn test` shows no new failures vs. `master` baseline
- [x] Template builds and stages successfully via `mvn exec:java -Dexec.mainClass=com.google.cloud.teleport.templates.PubsubToNewRelic ... --templateLocation=...`
- [x] Live Dataflow job launched from the staged template delivers a log to New Relic end-to-end
