### PR TITLE
feat: PR smoke test workflow for PubsubToNewRelic

### DIFF
--- a/.github/workflows/pr_smoke_test.yaml
+++ b/.github/workflows/pr_smoke_test.yaml
@@ -1,0 +1,106 @@
+name: PR smoke test
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: smoke-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_ID: logging-integrations
+  REGION: us-east1
+  BUCKET: gs://nr-pubsub-smoke-pvoore
+  SUBNETWORK: https://www.googleapis.com/compute/v1/projects/logging-integrations/regions/us-east1/subnetworks/preethi
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test:
+    name: Smoke test PubsubToNewRelic against logging-integrations
+    # Only run once a reviewer approves, and never for fork PRs (this job
+    # needs GCP + New Relic credentials that must not be exposed to
+    # untrusted, fork-supplied code).
+    if: github.event.review.state == 'approved' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_SMOKETEST_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SMOKETEST_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@6a7c903a70c8625ed6700fa299f5ddb4ca6822da # v2
+
+      - name: Run smoke test
+        id: smoke
+        env:
+          NR_LICENSE_KEY: ${{ secrets.NR_SMOKETEST_LICENSE_KEY }}
+          DISABLE_PUBLIC_IPS: "true"
+        run: |
+          set -euo pipefail
+          output_file="$(mktemp)"
+          ./scripts/gcp_pubsub_to_newrelic_smoke_test.sh | tee "$output_file"
+
+          {
+            echo "topic=$(grep '^Topic:' "$output_file" | awk '{print $2}')"
+            echo "subscription=$(grep '^Subscription:' "$output_file" | awk '{print $2}')"
+            echo "job_name=$(grep '^Job name:' "$output_file" | awk '{print $3}')"
+            echo "token=$(grep '^Verification token:' "$output_file" | awk '{print $3}')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify log reached New Relic
+        if: always() && steps.smoke.outputs.token != ''
+        env:
+          NR_QUERY_API_KEY: ${{ secrets.NR_QUERY_API_KEY }}
+          NR_ACCOUNT_ID: ${{ secrets.NR_ACCOUNT_ID }}
+          TOKEN: ${{ steps.smoke.outputs.token }}
+        run: |
+          set -euo pipefail
+          nrql="SELECT count(*) FROM Log WHERE message LIKE '%${TOKEN}%' SINCE 10 MINUTES AGO"
+          query="{ actor { account(id: ${NR_ACCOUNT_ID}) { nrql(query: \"$(printf '%s' "$nrql" | sed 's/"/\\\\"/g')\") { results } } } }"
+          payload=$(jq -n --arg q "$query" '{query: $q}')
+
+          for i in $(seq 1 20); do
+            result=$(curl -s -X POST https://api.newrelic.com/graphql \
+              -H "Content-Type: application/json" \
+              -H "Api-Key: ${NR_QUERY_API_KEY}" \
+              -d "$payload")
+            count=$(echo "$result" | jq -r '.data.actor.account.nrql.results[0].count // 0')
+            if [ "$count" -gt 0 ]; then
+              echo "Log verified in New Relic (count=$count) for token: ${TOKEN}"
+              exit 0
+            fi
+            echo "Not found yet (attempt $i/20), retrying in 15s..."
+            sleep 15
+          done
+
+          echo "::error::Log with token ${TOKEN} did not reach New Relic within timeout"
+          exit 1
+
+      - name: Cleanup GCP resources
+        if: always() && steps.smoke.outputs.job_name != ''
+        env:
+          NR_LICENSE_KEY: ${{ secrets.NR_SMOKETEST_LICENSE_KEY }}
+          TOPIC_NAME: ${{ steps.smoke.outputs.topic }}
+          SUB_NAME: ${{ steps.smoke.outputs.subscription }}
+          JOB_NAME: ${{ steps.smoke.outputs.job_name }}
+        run: ./scripts/gcp_pubsub_to_newrelic_smoke_test.sh --cleanup

--- a/.github/workflows/pr_smoke_test.yaml
+++ b/.github/workflows/pr_smoke_test.yaml
@@ -11,8 +11,8 @@ concurrency:
 env:
   PROJECT_ID: logging-integrations
   REGION: us-east1
-  BUCKET: gs://nr-pubsub-smoke-pvoore
-  SUBNETWORK: https://www.googleapis.com/compute/v1/projects/logging-integrations/regions/us-east1/subnetworks/preethi
+  BUCKET: gs://nr-dataflow-smoke-test
+  SUBNETWORK: https://www.googleapis.com/compute/v1/projects/logging-integrations/regions/us-east1/subnetworks/dataflow-smoke-test
 
 permissions:
   contents: read

--- a/scripts/gcp_pubsub_to_newrelic_smoke_test.sh
+++ b/scripts/gcp_pubsub_to_newrelic_smoke_test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  gcp_pubsub_to_newrelic_smoke_test.sh [--cleanup]
+
+Description:
+  Runs a GCP smoke test for the Pub/Sub to New Relic Dataflow template,
+  the same way a customer would run it: stage the template once, then
+  launch it with `gcloud dataflow jobs run` (no Maven/source needed to run).
+  By default, it will:
+    1) Create a test Pub/Sub topic and subscription
+    2) Build and stage the Dataflow template to GCS (from source)
+    3) Launch the staged template as a Dataflow job
+    4) Publish a unique test log message
+    5) Print verification steps for New Relic
+
+  With --cleanup, it deletes the test Pub/Sub resources and cancels the job.
+  TOPIC_NAME, SUB_NAME, and JOB_NAME must match the values printed by the
+  run you are cleaning up (or the ones you passed in explicitly).
+
+  If the script fails before the Dataflow job is launched, it automatically
+  rolls back any Pub/Sub topic/subscription it created.
+
+Required environment variables:
+  PROJECT_ID        GCP project ID
+  REGION            Dataflow region (for example: us-central1)
+  BUCKET            GCS bucket URI for staging/temp/template (for example: gs://my-bucket)
+  NR_LICENSE_KEY    New Relic license key (or set NR_LICENSE_KEY_FILE instead)
+
+Optional environment variables:
+  NR_LICENSE_KEY_FILE Path to a file containing the New Relic license key.
+                    Use this instead of NR_LICENSE_KEY to avoid the secret
+                    appearing in shell history or process listings.
+  NR_ENDPOINT       New Relic logs endpoint
+                    Default: https://log-api.newrelic.com/log/v1
+  TOPIC_NAME        Pub/Sub topic name to create/use
+                    Default: nr-smoke-topic-<timestamp>
+  SUB_NAME          Pub/Sub subscription name to create/use
+                    Default: nr-smoke-sub-<timestamp>
+  JOB_NAME          Dataflow job name
+                    Default: nr-smoke-<timestamp>
+  BATCH_COUNT       Default: 10
+  FLUSH_DELAY       Default: 2
+  PARALLELISM       Default: 1
+  USE_COMPRESSION   Default: true
+  DISABLE_CERT_VALIDATION Default: false
+  NETWORK           Compute Engine network for worker VMs (omit if using SUBNETWORK)
+  SUBNETWORK        Compute Engine subnetwork self-link for worker VMs.
+                    Required in projects without a "default" network.
+  DISABLE_PUBLIC_IPS Default: false. Set to true if the project enforces the
+                    compute.vmExternalIpAccess org policy (workers must not
+                    get external IPs). Requires the subnetwork to have
+                    Private Google Access enabled AND Cloud NAT configured
+                    on that subnetwork/region (workers otherwise have no
+                    path to reach the New Relic Logs API over the internet).
+  SKIP_TEMPLATE_BUILD Default: false. Set to true to reuse an already-staged
+                    template at ${BUCKET}/template/PubsubToNewRelic instead of
+                    rebuilding it.
+
+Examples:
+  PROJECT_ID=my-proj REGION=us-central1 BUCKET=gs://my-bucket NR_LICENSE_KEY=xxxx \
+  ./scripts/gcp_pubsub_to_newrelic_smoke_test.sh
+
+  PROJECT_ID=my-proj REGION=us-central1 BUCKET=gs://my-bucket NR_LICENSE_KEY_FILE=./nr_key.txt \
+  SUBNETWORK=https://www.googleapis.com/compute/v1/projects/my-proj/regions/us-central1/subnetworks/my-subnet \
+  DISABLE_PUBLIC_IPS=true \
+  TOPIC_NAME=nr-test-topic SUB_NAME=nr-test-sub JOB_NAME=nr-smoke-manual \
+  ./scripts/gcp_pubsub_to_newrelic_smoke_test.sh
+
+  PROJECT_ID=my-proj REGION=us-central1 BUCKET=gs://my-bucket NR_LICENSE_KEY=xxxx \
+  TOPIC_NAME=nr-test-topic SUB_NAME=nr-test-sub JOB_NAME=nr-smoke-manual \
+  ./scripts/gcp_pubsub_to_newrelic_smoke_test.sh --cleanup
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command not found: $cmd" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Error: required environment variable is not set: $name" >&2
+    exit 1
+  fi
+}
+
+topic_created=false
+sub_created=false
+job_launched=false
+
+rollback_on_failure() {
+  local exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    return
+  fi
+  echo >&2
+  echo "Failed (exit $exit_code)." >&2
+  if [[ "$job_launched" == "true" ]]; then
+    echo "Dataflow job may already be running. Nothing was auto-cancelled; use --cleanup to remove resources:" >&2
+    echo "  PROJECT_ID=$PROJECT_ID REGION=$REGION BUCKET=$BUCKET NR_LICENSE_KEY=*** TOPIC_NAME=$TOPIC_NAME SUB_NAME=$SUB_NAME JOB_NAME=$JOB_NAME $0 --cleanup" >&2
+    return
+  fi
+  echo "Rolling back Pub/Sub resources created by this run..." >&2
+  if [[ "$sub_created" == "true" ]]; then
+    gcloud pubsub subscriptions delete "$SUB_NAME" --project "$PROJECT_ID" || true
+  fi
+  if [[ "$topic_created" == "true" ]]; then
+    gcloud pubsub topics delete "$TOPIC_NAME" --project "$PROJECT_ID" || true
+  fi
+}
+trap rollback_on_failure EXIT
+
+cleanup_mode=false
+if [[ "${1:-}" == "--cleanup" ]]; then
+  cleanup_mode=true
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+elif [[ -n "${1:-}" ]]; then
+  echo "Error: unknown argument: $1" >&2
+  usage
+  exit 1
+fi
+
+require_cmd gcloud
+
+require_env PROJECT_ID
+require_env REGION
+require_env BUCKET
+
+if [[ "$BUCKET" != gs://* ]]; then
+  echo "Error: BUCKET must be a gs:// URI (got: $BUCKET)" >&2
+  exit 1
+fi
+
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | grep -q .; then
+  echo "Error: no active gcloud account. Run 'gcloud auth login' first." >&2
+  exit 1
+fi
+
+if [[ -z "${NR_LICENSE_KEY:-}" && -n "${NR_LICENSE_KEY_FILE:-}" ]]; then
+  NR_LICENSE_KEY="$(<"$NR_LICENSE_KEY_FILE")"
+fi
+require_env NR_LICENSE_KEY
+
+NR_ENDPOINT="${NR_ENDPOINT:-https://log-api.newrelic.com/log/v1}"
+BATCH_COUNT="${BATCH_COUNT:-10}"
+FLUSH_DELAY="${FLUSH_DELAY:-2}"
+PARALLELISM="${PARALLELISM:-1}"
+USE_COMPRESSION="${USE_COMPRESSION:-true}"
+DISABLE_CERT_VALIDATION="${DISABLE_CERT_VALIDATION:-false}"
+NETWORK="${NETWORK:-}"
+SUBNETWORK="${SUBNETWORK:-}"
+DISABLE_PUBLIC_IPS="${DISABLE_PUBLIC_IPS:-false}"
+SKIP_TEMPLATE_BUILD="${SKIP_TEMPLATE_BUILD:-false}"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+
+if [[ "$cleanup_mode" == "true" ]]; then
+  require_env TOPIC_NAME
+  require_env SUB_NAME
+  require_env JOB_NAME
+  echo "Cleaning up test resources..."
+  job_id="$(gcloud dataflow jobs list --region "$REGION" --project "$PROJECT_ID" \
+    --filter="name:$JOB_NAME AND state:Running" --format="value(id)" | head -n1)"
+  if [[ -n "$job_id" ]]; then
+    gcloud dataflow jobs cancel "$job_id" --region "$REGION" --project "$PROJECT_ID" || true
+  else
+    echo "No running job found matching name: $JOB_NAME (already cancelled, or never launched)"
+  fi
+  gcloud pubsub subscriptions delete "$SUB_NAME" --project "$PROJECT_ID" || true
+  gcloud pubsub topics delete "$TOPIC_NAME" --project "$PROJECT_ID" || true
+  echo "Cleanup complete."
+  trap - EXIT
+  exit 0
+fi
+
+require_cmd mvn
+
+TOPIC_NAME="${TOPIC_NAME:-nr-smoke-topic-$timestamp}"
+SUB_NAME="${SUB_NAME:-nr-smoke-sub-$timestamp}"
+JOB_NAME="${JOB_NAME:-nr-smoke-$timestamp}"
+INPUT_SUBSCRIPTION="projects/${PROJECT_ID}/subscriptions/${SUB_NAME}"
+TEMPLATE_LOCATION="${BUCKET}/template/PubsubToNewRelic"
+
+echo "Using project: $PROJECT_ID"
+echo "Using region: $REGION"
+echo "Using bucket: $BUCKET"
+echo "Using New Relic endpoint: $NR_ENDPOINT"
+echo "Creating topic: $TOPIC_NAME"
+echo "Creating subscription: $SUB_NAME"
+
+gcloud pubsub topics create "$TOPIC_NAME" --project "$PROJECT_ID" \
+  --labels=purpose=nr-pubsub-smoke-test
+topic_created=true
+
+gcloud pubsub subscriptions create "$SUB_NAME" --topic "$TOPIC_NAME" --project "$PROJECT_ID" \
+  --labels=purpose=nr-pubsub-smoke-test
+sub_created=true
+
+if [[ "$SKIP_TEMPLATE_BUILD" == "true" ]]; then
+  echo "Skipping template build, reusing: $TEMPLATE_LOCATION"
+else
+  echo "Building and staging template to: $TEMPLATE_LOCATION"
+  mvn -DskipTests compile exec:java \
+    -Dexec.mainClass=com.google.cloud.teleport.templates.PubsubToNewRelic \
+    -Dexec.cleanupDaemonThreads=false \
+    -Dexec.args="--runner=DataflowRunner \
+--project=${PROJECT_ID} \
+--region=${REGION} \
+--stagingLocation=${BUCKET}/staging \
+--tempLocation=${BUCKET}/temp \
+--templateLocation=${TEMPLATE_LOCATION}"
+fi
+
+echo "Launching Dataflow job from template: $JOB_NAME"
+network_args=()
+if [[ -n "$SUBNETWORK" ]]; then
+  network_args+=(--subnetwork="$SUBNETWORK")
+fi
+if [[ -n "$NETWORK" ]]; then
+  network_args+=(--network="$NETWORK")
+fi
+if [[ "$DISABLE_PUBLIC_IPS" == "true" ]]; then
+  network_args+=(--disable-public-ips)
+fi
+
+gcloud dataflow jobs run "$JOB_NAME" \
+  --gcs-location="$TEMPLATE_LOCATION" \
+  --region="$REGION" \
+  --project="$PROJECT_ID" \
+  --additional-user-labels=purpose=nr-pubsub-smoke-test \
+  "${network_args[@]}" \
+  --parameters="inputSubscription=${INPUT_SUBSCRIPTION},licenseKey=${NR_LICENSE_KEY},logsApiUrl=${NR_ENDPOINT},batchCount=${BATCH_COUNT},flushDelay=${FLUSH_DELAY},parallelism=${PARALLELISM},disableCertificateValidation=${DISABLE_CERT_VALIDATION},useCompression=${USE_COMPRESSION}" \
+  >/dev/null
+job_launched=true
+
+TOKEN="nr-test-${timestamp}"
+MESSAGE="{\"message\":\"${TOKEN} from gcp smoke test\"}"
+
+echo "Publishing test message..."
+gcloud pubsub topics publish "$TOPIC_NAME" --project "$PROJECT_ID" --message "$MESSAGE"
+
+echo
+echo "Smoke test launched successfully."
+echo "Job name: $JOB_NAME"
+echo "Template: $TEMPLATE_LOCATION"
+echo "Topic: $TOPIC_NAME"
+echo "Subscription: $SUB_NAME"
+echo "Verification token: $TOKEN"
+echo
+echo "Verify in New Relic Logs with query containing token: $TOKEN"
+echo "Optionally filter by plugin.source = gcp-dataflow-1.0.0"
+echo
+echo "Useful commands:"
+echo "  gcloud dataflow jobs list --region $REGION --project $PROJECT_ID"
+echo "  gcloud dataflow jobs describe $JOB_NAME --region $REGION --project $PROJECT_ID"
+echo
+echo "Cleanup command:"
+echo "  PROJECT_ID=$PROJECT_ID REGION=$REGION BUCKET=$BUCKET NR_LICENSE_KEY=*** TOPIC_NAME=$TOPIC_NAME SUB_NAME=$SUB_NAME JOB_NAME=$JOB_NAME $0 --cleanup"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/pr_smoke_test.yaml`) that automatically runs a live smoke test against `logging-integrations` once a PR is **approved** — not on every push. This mirrors the pipeline shape agreed for this repo's Dataflow template release process: test in a sandbox project, then publish to production on merge (see `publish_production_template.yaml` in #81, which handles the `network-monitoring-354214` half on merge to `master`).

Also commits `scripts/gcp_pubsub_to_newrelic_smoke_test.sh` itself — it existed only as local scratch work until now, and the workflow needs it in the repo to run.

## What the workflow does

1. Builds and stages the `PubsubToNewRelic` Dataflow template
2. Creates a throwaway Pub/Sub topic + subscription
3. Launches a real Dataflow job against them
4. Publishes a test message
5. Polls the New Relic NerdGraph API to confirm the log **actually arrived** (not just that the job launched)
6. Always tears down the GCP resources afterward (`--cleanup`), regardless of whether verification succeeded

## Trigger and security

- Fires on `pull_request_review` with `state == 'approved'`
- Restricted to **non-fork PRs only** — this job needs GCP + New Relic credentials that must never be exposed to untrusted, fork-supplied code (same trust boundary the repo's Trivy workflow already enforces)

## ⚠️ Not yet runnable

This workflow will fail until the following are configured (tracked separately via a `#help-tdp` request for GCP Workload Identity Federation into `logging-integrations`):

- Repo variables: `GCP_SMOKETEST_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SMOKETEST_SERVICE_ACCOUNT_EMAIL`
- Repo secrets: `NR_SMOKETEST_LICENSE_KEY` (ingest), `NR_QUERY_API_KEY` (NerdGraph query key), `NR_ACCOUNT_ID`

**We'll add these once the WIF request is fulfilled** — opening this now so the workflow logic itself is ready for review in parallel.

## Test plan

- [x] Workflow YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Output-parsing (topic/subscription/job/token) verified against the exact `echo` lines the script produces
- [ ] End-to-end run in CI — blocked on WIF + secrets above
- [x] The underlying script has already been run manually multiple times against `logging-integrations` and confirmed to deliver logs to New Relic end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)